### PR TITLE
Pass provider namespace via input

### DIFF
--- a/example_inputs/input.json
+++ b/example_inputs/input.json
@@ -1,7 +1,10 @@
 {
   "input": {
-    "provider_type": "vsphere",
-    "provider_name": "vcenter-test",
+    "provider": {
+      "namespace": "test_ns",
+      "type": "vsphere",
+      "name": "vcenter-test"
+    },
     "vm_moref": "vm-1234"
   }
 }

--- a/policies/io/konveyor/forklift/vmware/external_data.rego
+++ b/policies/io/konveyor/forklift/vmware/external_data.rego
@@ -2,11 +2,9 @@ package io.konveyor.forklift.vmware
 
 runtime := opa.runtime()
 
-provider_type      := input.provider_type
-provider_name      := input.provider_name
-provider_namespace := runtime.env["POD_NAMESPACE"]
+provider           := input.provider
 inventory_hostname := runtime.env["INVENTORY_HOSTNAME"]
-inventory_base_url := concat("/", ["https:/", inventory_hostname, "namespaces", provider_namespace, "providers", provider_type, provider_name])
+inventory_base_url := concat("/", ["https:/", inventory_hostname, "namespaces", provider.namespace, "providers", provider.type, provider.name])
 
 default is_test = false
 


### PR DESCRIPTION
It is better to pass the provider namespace in the input, as it is part as the context of the VM we analyze.