### PR TITLE
Get running in openshift

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,0 @@
-/usr/share/opa/policies/io/konveyor/forklift/vmware/*test.rego

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+policies/io/konveyor/forklift/vmware/*test.rego

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,1 @@
-policies/io/konveyor/forklift/vmware/*test.rego
+/usr/share/opa/policies/io/konveyor/forklift/vmware/*test.rego

--- a/README.md
+++ b/README.md
@@ -1,6 +1,61 @@
 # Konveyor > Forklift > Validation Rules
 
-To test the rules in the repository, you can install Open Policy Agent CLI (see [OPA doc](https://www.openpolicyagent.org/docs/latest/#running-opa)).
+When running as the `forklift-validation` pod in OpenShift, the rules can be called by making an https POST call to `<pod>/v1/data/io/konveyor/forklift/vmware/concerns`
+
+The call must provide a JSON payload containing the VMware provider namespace and name, and VM Managed Object Reference, in the following format:
+
+```
+{
+   "input": {
+      "provider": {
+        "namespace": "openshift-migration",
+        "name": "test"
+      },
+      "vm_moref": "vm-431"
+    }
+}
+```
+
+The return is a JSON structure containing the concerns relevant to that VM, for example:
+
+```
+{
+    "result": [
+        {
+            "assessment": "USB controllers are not currently supported by OpenShift Virtualization. The VM can be migrated but the devices attached to the USB controller will not be migrated.",
+            "category": "Warning",
+            "label": "USB controller detected"
+        },
+        {
+            "assessment": "Host/Node HA is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have this feature in the target environment.",
+            "category": "Warning",
+            "label": "VM running in HA-enabled cluster"
+        },
+        {
+            "assessment": "NUMA node affinity is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have this feature in the target environment.",
+            "category": "Warning",
+            "label": "NUMA node affinity detected"
+        },
+        {
+            "assessment": "Hot pluggable CPU or memory is not currently supported by OpenShift Virtualization. Review CPU or memory configuration after migration.",
+            "category": "Warning",
+            "label": "CPU/Memory hotplug detected"
+        },
+        {
+            "assessment": "CPU affinity is not supported by OpenShift Virtualization. The VM can be migrated but it will not have this feature in the target environment.",
+            "category": "Warning",
+            "label": "CPU affinity detected"
+        },
+        {
+            "assessment": "Distributed resource scheduling is not currently supported by OpenShift Virtualization. The VM can be migrated but it will not have this feature in the target environment.",
+            "category": "Information",
+            "label": "VM running in a DRS-enabled cluster"
+        }
+    ]
+}
+```
+
+The rules in the repository can be tested from the command lineusing the Open Policy Agent CLI (see [OPA doc](https://www.openpolicyagent.org/docs/latest/#running-opa)).
 
 Then you can run the unit tests with:
 
@@ -8,5 +63,13 @@ Then you can run the unit tests with:
 $ opa test policies --explain fails
 ```
 
-Whenever the rules are edited or updated, the relevant policies/io/konveyor/forklift/<provider>/rules_version.rego file should be updated with an incremented number.
+Whenever the rules are edited or updated, the relevant `policies/io/konveyor/forklift/<provider>/rules_version.rego` file **must** be updated with an incremented number, for example:
+
+```
+rules_version[version] {
+  version := {
+    "version": 3
+  }
+}
+```
 

--- a/README.md
+++ b/README.md
@@ -2,39 +2,11 @@
 
 To test the rules in the repository, you can install Open Policy Agent CLI (see [OPA doc](https://www.openpolicyagent.org/docs/latest/#running-opa)).
 
-Then, you can evaluate the example input:
-
-```
-$ export INVENTORY_HOSTNAME=forklift-inventory-openshift-migration.apps.cluster.company.com
-$ opa eval --data policies --input example_inputs/single_vm.json "data.io.konveyor.forklift.vmware.concerns"
-```
-
-You can also run the unit tests with:
+Then you can run the unit tests with:
 
 ```
 $ opa test policies --explain fails
 ```
 
-# Running OPA as a REST API
-
-The Dockerfile allows you to create a container image.
-
-```
-$ podman build -t quay.io/example.com/opa:latest .
-```
-
-Then, this image can be used to start the OPA REST server.
-
-```
-$ podman run --detach --rm --publish 8181 quay.io/example.com/opa:latest
-```
-
-The image is very basic right now, so it will listen on port 8181.
-You can ask for a decision using the example input file:
-
-```
-$ curl localhost:8181/v1/data/io/konveyor/forklift/vmware \
-    -d @example_inputs/api_single_vm.json \
-    -H 'Content-Type: application/json'
-```
+Whenever the rules are edited or updated, the relevant policies/io/konveyor/forklift/<provider>/rules_version.rego file should be updated with an incremented number.
 

--- a/deployment-opa.yaml
+++ b/deployment-opa.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: forklift-validation
+  labels:
+    app: forklift-validation
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: forklift-validation
+  template:
+    metadata:
+      labels:
+        app: forklift-validation
+      name: forklift-validation
+    spec:
+      containers:
+      - name: forklift-validation
+        image: 'quay.io/pmcgowan/forklift-validation:latest'
+        ports:
+        - name: http
+          containerPort: 8181
+        env:
+        - name: FORKLIFT_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace

--- a/deployment-opa.yaml
+++ b/deployment-opa.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: forklift-validation
-        image: 'quay.io/pmcgowan/forklift-validation:get_running_in_openshift'
+        image: 'quay.io/konveyor/forklift-validation:latest'
         ports:
         - name: http
           containerPort: 8181

--- a/deployment-opa.yaml
+++ b/deployment-opa.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: forklift-validation
-        image: 'quay.io/pmcgowan/forklift-validation:latest'
+        image: 'quay.io/pmcgowan/forklift-validation:get_running_in_openshift'
         ports:
         - name: http
           containerPort: 8181

--- a/example_inputs/single_vm_cli.json
+++ b/example_inputs/single_vm_cli.json
@@ -3,5 +3,5 @@
     "namespace": "openshift-migration",
     "name": "test"
   },
-  "vm_moref": "vm-2851"
+  "vm_moref": "vm-2851a"
 }

--- a/example_inputs/single_vm_server.json
+++ b/example_inputs/single_vm_server.json
@@ -1,0 +1,9 @@
+  {
+   "input": {
+      "provider": {
+        "namespace": "openshift-migration",
+        "name": "test"
+      },
+      "vm_moref": "vm-431"
+    }
+}

--- a/policies/io/konveyor/forklift/vmware/external_data.rego
+++ b/policies/io/konveyor/forklift/vmware/external_data.rego
@@ -4,8 +4,11 @@ runtime            := opa.runtime()
 provider           := input.provider
 vm_moref           := input.vm_moref
 inventory_hostname := concat(":", [runtime.env["FORKLIFT_INVENTORY_SERVICE_HOST"], runtime.env["FORKLIFT_INVENTORY_SERVICE_PORT"]])
+trace(sprintf("** debug ** inventory_hostname: %v", [inventory_hostname]))
 inventory_url      := concat("/", ["https:/", inventory_hostname, "namespaces", provider.namespace, "providers", "vsphere", provider.name, "workloads", vm_moref])
+trace(sprintf("** debug ** inventory_url: %v", [inventory_url]))
 vm                 := http.send({"url": inventory_url, "method": "get", "tls_insecure_skip_verify": true}).body
+trace(sprintf("** debug ** vm name: %v", [vm.name]))
 
 
 

--- a/policies/io/konveyor/forklift/vmware/external_data.rego
+++ b/policies/io/konveyor/forklift/vmware/external_data.rego
@@ -3,7 +3,7 @@ package io.konveyor.forklift.vmware
 runtime            := opa.runtime()
 provider           := input.provider
 vm_moref           := input.vm_moref
-inventory_hostname := runtime.env["INVENTORY_HOSTNAME"]
+inventory_hostname := concat(":", [runtime.env["FORKLIFT_INVENTORY_SERVICE_HOST"], runtime.env["FORKLIFT_INVENTORY_SERVICE_PORT"]])
 inventory_url      := concat("/", ["https:/", inventory_hostname, "namespaces", provider.namespace, "providers", "vsphere", provider.name, "workloads", vm_moref])
 vm                 := http.send({"url": inventory_url, "method": "get", "tls_insecure_skip_verify": true}).body
 

--- a/policies/io/konveyor/forklift/vmware/external_data.rego
+++ b/policies/io/konveyor/forklift/vmware/external_data.rego
@@ -4,11 +4,14 @@ runtime            := opa.runtime()
 provider           := input.provider
 vm_moref           := input.vm_moref
 inventory_hostname := concat(":", [runtime.env["FORKLIFT_INVENTORY_SERVICE_HOST"], runtime.env["FORKLIFT_INVENTORY_SERVICE_PORT"]])
-trace(sprintf("** debug ** inventory_hostname: %v", [inventory_hostname]))
 inventory_url      := concat("/", ["https:/", inventory_hostname, "namespaces", provider.namespace, "providers", "vsphere", provider.name, "workloads", vm_moref])
-trace(sprintf("** debug ** inventory_url: %v", [inventory_url]))
 vm                 := http.send({"url": inventory_url, "method": "get", "tls_insecure_skip_verify": true}).body
-trace(sprintf("** debug ** vm name: %v", [vm.name]))
+
+debug = {
+  trace(sprintf("** debug ** inventory_hostname: %v", [inventory_hostname]))
+  trace(sprintf("** debug ** inventory_url: %v", [inventory_url]))
+  trace(sprintf("** debug ** vm name: %v", [vm.name]))
+}
 
 
 

--- a/policies/io/konveyor/forklift/vmware/external_data.rego
+++ b/policies/io/konveyor/forklift/vmware/external_data.rego
@@ -7,7 +7,7 @@ inventory_hostname := concat(":", [runtime.env["FORKLIFT_INVENTORY_SERVICE_HOST"
 inventory_url      := concat("/", ["https:/", inventory_hostname, "namespaces", provider.namespace, "providers", "vsphere", provider.name, "workloads", vm_moref])
 vm                 := http.send({"url": inventory_url, "method": "get", "tls_insecure_skip_verify": true}).body
 
-debug = {
+debugging = {
   trace(sprintf("** debug ** inventory_hostname: %v", [inventory_hostname]))
   trace(sprintf("** debug ** inventory_url: %v", [inventory_url]))
   trace(sprintf("** debug ** vm name: %v", [vm.name]))

--- a/policies/io/konveyor/forklift/vmware/external_data.rego
+++ b/policies/io/konveyor/forklift/vmware/external_data.rego
@@ -7,7 +7,7 @@ inventory_hostname := concat(":", [runtime.env["FORKLIFT_INVENTORY_SERVICE_HOST"
 inventory_url      := concat("/", ["https:/", inventory_hostname, "namespaces", provider.namespace, "providers", "vsphere", provider.name, "workloads", vm_moref])
 vm                 := http.send({"url": inventory_url, "method": "get", "tls_insecure_skip_verify": true}).body
 
-debugging = {
+debug {
   trace(sprintf("** debug ** inventory_hostname: %v", [inventory_hostname]))
   trace(sprintf("** debug ** inventory_url: %v", [inventory_url]))
   trace(sprintf("** debug ** vm name: %v", [vm.name]))

--- a/policies/io/konveyor/forklift/vmware/rules_version.rego
+++ b/policies/io/konveyor/forklift/vmware/rules_version.rego
@@ -2,6 +2,6 @@ package io.konveyor.forklift.vmware
 
 rules_version[version] {
   version := {
-    "Version": 1
+    "version": 1
   }
 }

--- a/policies/io/konveyor/forklift/vmware/rules_version.rego
+++ b/policies/io/konveyor/forklift/vmware/rules_version.rego
@@ -1,0 +1,7 @@
+package io.konveyor.forklift.vmware
+
+rules_version[version] {
+  version := {
+    "Version": 1
+  }
+}

--- a/service-opa.yaml
+++ b/service-opa.yaml
@@ -1,0 +1,15 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: forklift-validation
+  labels:
+    app: forklift-validation
+spec:
+  type: NodePort
+  selector:
+    app: forklift-validation
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8181
+      targetPort: 8181

--- a/service-opa.yaml
+++ b/service-opa.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: forklift-validation
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     app: forklift-validation
   ports:


### PR DESCRIPTION
This PR adds the changes necessary to get forklift-validation running as a pod in OpenShift. The deployment-opa.yaml and service-pa.yaml files can temporarily be used to hand-create the deployment and service, until the operator can install these