### PR TITLE
Add opa v0.27.1 binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3-201
 
-RUN curl -sL -o /usr/bin/opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64 && chmod 0755 /usr/bin/opa
+COPY opa-v0.27.1 /usr/bin/opa
 COPY policies /usr/share/opa/policies/
 COPY entrypoint.sh /
 


### PR DESCRIPTION
This is an ugly hack to allow building downstream images. With the binary directly in the repository, everything is self contained, so Cachito will download the opa binary and we will be able to use it. The downside is that putting binaries is a wrong practice, so we'll need to revert this hack. This is why I limit this change to the release-v2.0.0 branch.