### PR TITLE
Update provider object and workload URL.

### DIFF
--- a/policies/io/konveyor/forklift/vmware/external_data.rego
+++ b/policies/io/konveyor/forklift/vmware/external_data.rego
@@ -9,7 +9,7 @@ ca_tls_cert_file                := runtime.env["CA_TLS_CERTIFICATE"]
 inventory_service               := runtime.env["INVENTORY_SERVICE"]
 inventory_hostname              := concat(".", [inventory_service, namespace, "svc", "cluster", "local"])
 inventory_socket                := concat(":", [inventory_hostname, forklift_inventory_service_port])
-inventory_url                   := concat("/", ["https:/", inventory_socket, "namespaces", provider.namespace, "providers", "vsphere", provider.name, "workloads", vm_moref])
+inventory_url                   := concat("/", ["https:/", inventory_socket, "providers", "vsphere", provider.uid, "workloads", vm_moref])
 vm                              := http.send({"url": inventory_url, "method": "get", "tls_ca_cert_file": ca_tls_cert_file}).body
 
 debug {


### PR DESCRIPTION
Update for compatibility with GA inventory schema (re: https://github.com/konveyor/forklift-controller/pull/191)
Providers (all OCP resources) identified by UID instead of namespace/name.