### PR TITLE
Revert "Add opa v0.27.1 binary"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3-201
 
-COPY opa-v0.27.1 /usr/bin/opa
+RUN curl -sL -o /usr/bin/opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64 && chmod 0755 /usr/bin/opa
 COPY policies /usr/share/opa/policies/
 COPY entrypoint.sh /
 


### PR DESCRIPTION
Reverts konveyor/forklift-validation#17.
Downstream we now have an intermediate image to build opa, so that it can be added to the validation image.