### PR TITLE
Change wording for snapshot rule

### DIFF
--- a/policies/io/konveyor/forklift/vmware/rules_version.rego
+++ b/policies/io/konveyor/forklift/vmware/rules_version.rego
@@ -1,6 +1,6 @@
 package io.konveyor.forklift.vmware
 
-RULES_VERSION := 3
+RULES_VERSION := 4
 
 rules_version = {
     "rules_version": RULES_VERSION

--- a/policies/io/konveyor/forklift/vmware/snapshot.rego
+++ b/policies/io/konveyor/forklift/vmware/snapshot.rego
@@ -9,6 +9,6 @@ concerns[flag] {
     flag := {
         "category": "Information",
         "label": "VM snapshot detected",
-        "assessment": "Online snapshots are not currently supported in OpenShift Virtualization."
+        "assessment": "Online snapshots are not currently supported by OpenShift Virtualization."
     }
 }

--- a/policies/io/konveyor/forklift/vmware/snapshot.rego
+++ b/policies/io/konveyor/forklift/vmware/snapshot.rego
@@ -9,6 +9,6 @@ concerns[flag] {
     flag := {
         "category": "Information",
         "label": "VM snapshot detected",
-        "assessment": "Warm migration may not be possible for this VM"
+        "assessment": "Online snapshots are not currently supported in OpenShift Virtualization."
     }
 }


### PR DESCRIPTION
This PR changes the wording of the snapshot rule as this is no longer relevant for warm migration, but it's still useful to provide an informational notice to the user that online snapshots are not supported