### PR TITLE
BZ 1953938 - Use a name validation message without new line or tab

### DIFF
--- a/policies/io/konveyor/forklift/vmware/name.rego
+++ b/policies/io/konveyor/forklift/vmware/name.rego
@@ -24,6 +24,6 @@ concerns[flag] {
     flag := {
         "category": "Critical",
         "label": "Invalid VM Name",
-        "assessment": "Kubernetes only supports names that follow DNS subdomain name as defined in RFC 1123. This means that the name must:\n\t- contain no more than 64 characters\n\t- contain only lowercase alphanumeric characters or '-'\n\t- start with an alphanumeric character\n\t- end with an alphanumeric character"
+        "assessment": "Kubernetes only supports names that follow DNS subdomain name as defined in RFC 1123. This means that the name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 64 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters."
     }
 }


### PR DESCRIPTION
Having formatting characters in the messages can interfere with the UI renderer that will likely remove them. The name validation rule message was the only one to have that kind of characters. This pull request replaces the message with longer sentences, all in one line.