### PR TITLE
added oVirt rule to detect USB devices attached from host

### DIFF
--- a/policies/io/konveyor/forklift/ovirt/host_devices_test.rego
+++ b/policies/io/konveyor/forklift/ovirt/host_devices_test.rego
@@ -9,7 +9,7 @@ test_without_host_devices {
 test_with_host_devices {
     mock_vm := { "name": "test",
                  "hostDevices": [
-                    { "some": "thing" }
+                    { "capability": "thing" }
                   ]
                 }
     results = concerns with input as mock_vm

--- a/policies/io/konveyor/forklift/ovirt/host_usb_device.rego
+++ b/policies/io/konveyor/forklift/ovirt/host_usb_device.rego
@@ -1,0 +1,15 @@
+package io.konveyor.forklift.ovirt
+
+host_usb_device [i] {
+    some i
+    regex.match(`usb_device`, input.hostDevices[i].capability)
+}
+
+concerns[flag] {
+    count(host_usb_device) > 0
+    flag := {
+        "category": "Critical",
+        "label": "Host USB device",
+        "assessment": "A host USB device has been attached to this VM, which is not currently supported by OpenShift Virtualization. The VM will not be migrated."
+    }
+}

--- a/policies/io/konveyor/forklift/ovirt/host_usb_device_test.rego
+++ b/policies/io/konveyor/forklift/ovirt/host_usb_device_test.rego
@@ -1,0 +1,22 @@
+package io.konveyor.forklift.ovirt
+ 
+test_without_host_usb_device {
+    mock_vm := { "name": "test", "hostDevices": [] }
+    results = concerns with input as mock_vm
+    count(results) == 0
+}
+
+test_with_host_usb_device {
+    mock_vm := { "name": "test",
+                 "hostDevices": [
+                    {
+                        "capability": "usb_device",
+                        "product": "2.0 root hub",
+                        "vendor": "Linux Foundation"
+                    }
+                  ],
+                }
+    results = concerns with input as mock_vm
+    # count should be 2 as this test also invalidates the host_devices rule
+    count(results) == 2
+}


### PR DESCRIPTION
This OPA rule checks for the presence of a host USB device that has been attached to the VM. The VM will not be migrated if such a device is found.