### PR TITLE
Change rule wording post vmio

### DIFF
--- a/policies/io/konveyor/forklift/ovirt/disk_interface_type.rego
+++ b/policies/io/konveyor/forklift/ovirt/disk_interface_type.rego
@@ -13,8 +13,8 @@ number_of_disks [i] {
 concerns[flag] {
     count(valid_disk_interfaces) != count(number_of_disks)
     flag := {
-        "category": "Critical",
+        "category": "Warning",
         "label": "Unsupported disk interface type detected",
-        "assessment": "The disk interface type is not supported by OpenShift Virtualization (only sata, virtio_scsi and virtio interface types are currently supported). The VM will not be migrated."
+        "assessment": "The disk interface type is not supported by OpenShift Virtualization (only sata, virtio_scsi and virtio interface types are currently supported). The migrated VM will be given a virtio disk interface type."
     }
 }

--- a/policies/io/konveyor/forklift/ovirt/disk_status.rego
+++ b/policies/io/konveyor/forklift/ovirt/disk_status.rego
@@ -9,7 +9,7 @@ concerns[flag] {
     count(invalid_disk_status) > 0
     flag := {
         "category": "Critical",
-        "label": "VM has a disk status condition that prevents migration",
-        "assessment": "One or more of the VM's disks has an illegal or locked status condition. The VM will not be migrated."
+        "label": "VM has an illegal or locked disk status condition",
+        "assessment": "One or more of the VM's disks has an illegal or locked status condition. The VM disk transfer is likely to fail."
     }
 }

--- a/policies/io/konveyor/forklift/ovirt/disk_storage_type.rego
+++ b/policies/io/konveyor/forklift/ovirt/disk_storage_type.rego
@@ -10,6 +10,6 @@ concerns[flag] {
     flag := {
         "category": "Critical",
         "label": "Unsupported disk storage type detected",
-        "assessment": "The VM has a disk with a storage type other than 'image', and this is not currently supported by OpenShift Virtualization. The VM will not be migrated."
+        "assessment": "The VM has a disk with a storage type other than 'image', which is not currently supported by OpenShift Virtualization. The VM disk transfer is likely to fail."
     }
 }

--- a/policies/io/konveyor/forklift/ovirt/illegal_images.rego
+++ b/policies/io/konveyor/forklift/ovirt/illegal_images.rego
@@ -11,6 +11,6 @@ concerns[flag] {
     flag := {
         "category": "Critical",
         "label": "Illegal disk images detected",
-        "assessment": "The VM has one or more snapshots with disks in ILLEGAL state. This is not currently supported by OpenShift Virtualization. The VM will not be migrated."
+        "assessment": "The VM has one or more snapshots with disks in ILLEGAL state, which is is not currently supported by OpenShift Virtualization. The VM disk transfer is likely to fail."
     }
 }

--- a/policies/io/konveyor/forklift/ovirt/illegal_images.rego
+++ b/policies/io/konveyor/forklift/ovirt/illegal_images.rego
@@ -11,6 +11,6 @@ concerns[flag] {
     flag := {
         "category": "Critical",
         "label": "Illegal disk images detected",
-        "assessment": "The VM has one or more snapshots with disks in ILLEGAL state, which is is not currently supported by OpenShift Virtualization. The VM disk transfer is likely to fail."
+        "assessment": "The VM has one or more snapshots with disks in ILLEGAL state, which is not currently supported by OpenShift Virtualization. The VM disk transfer is likely to fail."
     }
 }

--- a/policies/io/konveyor/forklift/ovirt/nic_interface_type.rego
+++ b/policies/io/konveyor/forklift/ovirt/nic_interface_type.rego
@@ -13,9 +13,9 @@ number_of_nics [i] {
 concerns[flag] {
     count(valid_nic_interfaces) != count(number_of_nics)
     flag := {
-        "category": "Critical",
+        "category": "Warning",
         "label": "Unsupported NIC interface type detected",
-        "assessment": "The NIC interface type is not supported by OpenShift Virtualization (only e1000, rtl8139 and virtio interface types are currently supported). The VM will not be migrated."
+        "assessment": "The NIC interface type is not supported by OpenShift Virtualization (only e1000, rtl8139 and virtio interface types are currently supported). The migrated VM will be given a virtio NIC interface type."
     }
 }
 

--- a/policies/io/konveyor/forklift/ovirt/nic_pci_passthrough.rego
+++ b/policies/io/konveyor/forklift/ovirt/nic_pci_passthrough.rego
@@ -8,9 +8,9 @@ nic_set_to_pci_passthrough [i] {
 concerns[flag] {
     count(nic_set_to_pci_passthrough) > 0
     flag := {
-        "category": "Critical",
+        "category": "Warning",
         "label": "NIC with host device passthrough detected",
-        "assessment": "The VM is using a vNIC profile configured for host device passthrough, which is not currently supported by OpenShift Virtualization. The VM will not be migrated."
+        "assessment": "The VM is using a vNIC profile configured for host device passthrough, which is not currently supported by OpenShift Virtualization. The VM will be configured with an SRIOV NIC, but the destination network will need to be set up correctly."
     }
 }
 

--- a/policies/io/konveyor/forklift/ovirt/rules_version.rego
+++ b/policies/io/konveyor/forklift/ovirt/rules_version.rego
@@ -1,6 +1,6 @@
 package io.konveyor.forklift.ovirt
 
-RULES_VERSION := 5
+RULES_VERSION := 6
 
 rules_version = {
     "rules_version": RULES_VERSION

--- a/policies/io/konveyor/forklift/ovirt/usb.rego
+++ b/policies/io/konveyor/forklift/ovirt/usb.rego
@@ -9,8 +9,8 @@ has_usb_enabled = value {
 concerns[flag] {
     has_usb_enabled
     flag := {
-        "category": "Critical",
+        "category": "Warning",
         "label": "USB support enabled",
-        "assessment": "The VM has USB support enabled, but USB devices are not currently supported by OpenShift Virtualization. The VM will not be migrated."
+        "assessment": "The VM has USB support enabled, but USB device attachment is not currently supported by OpenShift Virtualization."
     }
 }

--- a/policies/io/konveyor/forklift/ovirt/vm_status.rego
+++ b/policies/io/konveyor/forklift/ovirt/vm_status.rego
@@ -16,7 +16,7 @@ concerns[flag] {
     not legal_vm_status
     flag := {
         "category": "Critical",
-        "label": "VM has a status condition that prevents migration",
-        "assessment": "The VM's status is not 'up' or 'down'. The VM will not be migrated."
+        "label": "VM has a status condition that may prevent successful migration",
+        "assessment": "The VM's status is not 'up' or 'down'. Attempting to migrate this VM may fail."
     }
 }

--- a/policies/io/konveyor/forklift/ovirt/watchdog.rego
+++ b/policies/io/konveyor/forklift/ovirt/watchdog.rego
@@ -11,6 +11,6 @@ concerns[flag] {
     flag := {
         "category": "Warning",
         "label": "Watchdog detected",
-        "assessment": "The VM is configured with a watchdog device, which is not currently supported by OpenShift Virtualization. A watchdog device will not be present on the destination VM."
+        "assessment": "The VM is configured with a watchdog device, which is not currently supported by OpenShift Virtualization. A watchdog device will not be present in the destination VM."
     }
 }

--- a/policies/io/konveyor/forklift/ovirt/watchdog.rego
+++ b/policies/io/konveyor/forklift/ovirt/watchdog.rego
@@ -9,8 +9,8 @@ has_watchdog_enabled = true {
 concerns[flag] {
     has_watchdog_enabled
     flag := {
-        "category": "Critical",
+        "category": "Warning",
         "label": "Watchdog detected",
-        "assessment": "The VM is configured with a watchdog device, which is not currently supported by OpenShift Virtualization. The VM will not be migrated."
+        "assessment": "The VM is configured with a watchdog device, which is not currently supported by OpenShift Virtualization. A watchdog device will not be present on the destination VM."
     }
 }


### PR DESCRIPTION
This PR changes some of the validation rule severity and wording. The original wording reflected the fact that VMIO was used for disk transfer, and the rule wording matched the VMIO conditions that would block migration. Now that VMIO is no longer used, some of the wording is no longer relevant