### PR TITLE
Switch to static opa binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 
-RUN curl -sL -o /usr/bin/opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64 && chmod 0755 /usr/bin/opa
+RUN curl -sL -o /usr/bin/opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64_static && chmod 0755 /usr/bin/opa
 COPY policies /usr/share/opa/policies/
 COPY entrypoint.sh /
 


### PR DESCRIPTION
- Prevents runtime issues due to newer opa build environment changes