### PR TITLE
Change the type of "Invalid VM name" concern to a warning.

### DIFF
--- a/policies/io/konveyor/forklift/ovirt/name.rego
+++ b/policies/io/konveyor/forklift/ovirt/name.rego
@@ -22,8 +22,8 @@ concerns[flag] {
     valid_vm_string
     not valid_vm_name
     flag := {
-        "category": "Critical",
+        "category": "Warning",
         "label": "Invalid VM Name",
-        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 64 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters. The VM will not be migrated."
+        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 64 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters. The VM name will be automatically changed during the migration to meet the RFC convention."
     }
 }

--- a/policies/io/konveyor/forklift/vmware/name.rego
+++ b/policies/io/konveyor/forklift/vmware/name.rego
@@ -22,8 +22,8 @@ concerns[flag] {
     valid_vm
     not valid_vm_name
     flag := {
-        "category": "Critical",
+        "category": "Warning",
         "label": "Invalid VM Name",
-        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 64 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters."
+        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 64 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters. The VM name will be automatically changed during the migration to meet the RFC convention."
     }
 }


### PR DESCRIPTION
This PR changes the concerned type to warning since the [VM name is now automatically changed](https://github.com/konveyor/forklift-controller/pull/448) as part of the controller flow,
this validation is no longer blocking the migration, 

