### PR TITLE
add ovirt cpu policy rule

### DIFF
--- a/policies/io/konveyor/forklift/ovirt/cpu_policy.rego
+++ b/policies/io/konveyor/forklift/ovirt/cpu_policy.rego
@@ -1,0 +1,17 @@
+package io.konveyor.forklift.ovirt
+
+default not_supported_cpu_policy = false
+
+# no need to check for 'manual' pinning policy because 'cpuAffinity' is validated by the 'cpu_tune' policy
+not_supported_cpu_policy = true {
+    regex.match(`resize_and_pin_numa|isolate_threads`, input.cpuPinningPolicy)
+}
+
+concerns[flag] {
+    not_supported_cpu_policy
+    flag := {
+        "category": "Warning",
+        "label": "Unsupported CPU pinning policy detected",
+        "assessment": "Resize and Pin NUMA and Isolated Threads are not supported by OpenShift Virtualization. Some functionality may be missing after the VM is migrated."
+    }
+}

--- a/policies/io/konveyor/forklift/ovirt/cpu_policy_test.rego
+++ b/policies/io/konveyor/forklift/ovirt/cpu_policy_test.rego
@@ -1,0 +1,47 @@
+package io.konveyor.forklift.ovirt
+
+test_with_none {
+    mock_vm := {
+        "name": "test",
+        "cpuPinningPolicy": "none"
+    }
+    results := concerns with input as mock_vm
+    count(results) == 0
+}
+
+test_with_dedicated {
+    mock_vm := {
+        "name": "test",
+        "cpuPinningPolicy": "dedicated"
+    }
+    results := concerns with input as mock_vm
+    count(results) == 0
+}
+
+test_with_manual {
+    mock_vm := {
+        "name": "test",
+        "cpuPinningPolicy": "manual",
+        "cpuAffinity": [0,2]
+    }
+    results := concerns with input as mock_vm
+    count(results) == 1
+}
+
+test_with_resize_and_pin_numa {
+    mock_vm := {
+        "name": "test",
+        "cpuPinningPolicy": "resize_and_pin_numa"
+    }
+    results := concerns with input as mock_vm
+    count(results) == 1
+}
+
+test_with_isolate_threads {
+    mock_vm := {
+        "name": "test",
+        "cpuPinningPolicy": "isolate_threads"
+    }
+    results := concerns with input as mock_vm
+    count(results) == 1
+}


### PR DESCRIPTION
When having a VM set with CPU policy, it's only partially supported.
`Manual` pinning it taken care in the cpu tune rule. `Dedicated` is
supported and added in PR:
https://github.com/konveyor/forklift-controller/pull/459