### PR TITLE
backport Change the type of "Invalid VM name" to a warning.

### DIFF
--- a/policies/io/konveyor/forklift/ovirt/name.rego
+++ b/policies/io/konveyor/forklift/ovirt/name.rego
@@ -22,8 +22,8 @@ concerns[flag] {
     valid_vm_string
     not valid_vm_name
     flag := {
-        "category": "Critical",
+        "category": "Warning",
         "label": "Invalid VM Name",
-        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 64 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters. The VM will not be migrated."
+        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 64 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters. The VM will be renamed automatically during the migration to meet the RFC convention."
     }
 }

--- a/policies/io/konveyor/forklift/vmware/name.rego
+++ b/policies/io/konveyor/forklift/vmware/name.rego
@@ -22,8 +22,8 @@ concerns[flag] {
     valid_vm
     not valid_vm_name
     flag := {
-        "category": "Critical",
+        "category": "Warning",
         "label": "Invalid VM Name",
-        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 64 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters."
+        "assessment": "The VM name must comply with the DNS subdomain name format defined in RFC 1123. The name can contain lowercase letters (a-z), numbers (0-9), and hyphens (-), up to a maximum of 64 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, periods (.), or special characters. The VM will be renamed automatically during the migration to meet the RFC convention."
     }
 }


### PR DESCRIPTION
Change the type of "Invalid VM name" from critical to a warning and not block migration even if the VM name is not compatible.